### PR TITLE
Built out the Cert class

### DIFF
--- a/src/Certain/Cert.php
+++ b/src/Certain/Cert.php
@@ -10,6 +10,8 @@
 
 namespace Certain;
 
+use \DateTime;
+
 /**
  * Cert
  *
@@ -22,6 +24,12 @@ class Cert
 
     protected $cert = false;
 
+    protected $cn;
+
+    protected $validFrom;
+
+    protected $validTo;
+
     protected $host = false;
 
     protected $parameters = false;
@@ -29,11 +37,31 @@ class Cert
     public function __construct($cert, $parent = null)
     {
         $this->cert = $cert;
-        $this->parameters = openssl_x509_parse($cert);
+        $parameters = $this->parameters = openssl_x509_parse($cert);
 
         if (isset($parent)) {
             $this->parent = $parent;
         }
+
+        $this->cn = $parameters['subject']['CN'];
+
+        if(isset($parameters['validTo_time_t']))
+        {
+            $validTo = new DateTime();
+            $validTo->setTimestamp($parameters['validTo_time_t']);
+        }else{
+            $validTo = Util::getDateFromSSLFormat($parameters['validTo']);
+        }
+        $this->validTo = $validTo;
+
+        if(isset($parameters['validFrom_time_t']))
+        {
+            $validFrom = new DateTime();
+            $validFrom->setTimestamp($parameters['validFrom_time_t']);
+        }else{
+            $validFrom = Util::getDateFromSSLFormat($parameters['validFrom']);
+        }
+        $this->validFrom = $validFrom;
     }
 
     public function setHost($host)
@@ -54,6 +82,21 @@ class Cert
     public function getParameters()
     {
         return $this->parameters;
+    }
+
+    public function getValidFrom()
+    {
+        return $this->validFrom;
+    }
+
+    public function getValidTo()
+    {
+        return $this->validTo;
+    }
+
+    public function getCommonName()
+    {
+        return $this->cn;
     }
 
 }

--- a/src/Certain/Cert.php
+++ b/src/Certain/Cert.php
@@ -45,20 +45,18 @@ class Cert
 
         $this->cn = $parameters['subject']['CN'];
 
-        if(isset($parameters['validTo_time_t']))
-        {
+        if (isset($parameters['validTo_time_t'])) {
             $validTo = new DateTime();
             $validTo->setTimestamp($parameters['validTo_time_t']);
-        }else{
+        } else {
             $validTo = Util::getDateFromSSLFormat($parameters['validTo']);
         }
         $this->validTo = $validTo;
 
-        if(isset($parameters['validFrom_time_t']))
-        {
+        if (isset($parameters['validFrom_time_t'])) {
             $validFrom = new DateTime();
             $validFrom->setTimestamp($parameters['validFrom_time_t']);
-        }else{
+        } else {
             $validFrom = Util::getDateFromSSLFormat($parameters['validFrom']);
         }
         $this->validFrom = $validFrom;

--- a/src/Certain/Util.php
+++ b/src/Certain/Util.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * This file is part of the Certain package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Certain;
+
+use \DateTime;
+
+/**
+ * Util
+ *
+ *
+ */
+class Util
+{
+    public static function getDateFromSSLFormat($dateString)
+    {
+        //14 01 15 14 53 24 Z
+        $dateString = rtrim($dateString, 'Z');
+
+        //14 01 15 14 53 24
+        // y  m  d  H  i  s
+        $format = 'ymdHis';
+
+        return DateTime::createFromFormat($format, $dateString, new \DateTimeZone('UTC'));
+    }
+
+}

--- a/tests/Certain/Test/CertFactoryTest.php
+++ b/tests/Certain/Test/CertFactoryTest.php
@@ -13,6 +13,7 @@ namespace Certain\Test;
 
 use Certain\CertFactory;
 
+
 class CertFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetCertFromChain()
@@ -42,9 +43,45 @@ class CertFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Certain\Cert', $grandParent, 'getCertFromFiles properly populates grand parent');
     }
 
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetCertFromFiles_PermissionException()
+    {
+        $files = array(
+            '/root/cert1.crt',
+            '/root/cert2.crt',
+            '/root/cert3.crt',
+        );
+        CertFactory::getCertFromFiles($files);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetCertFromFiles_WrongPathException()
+    {
+        $files = array(
+            '/fakepath/cert1.crt',
+            '/fakepath/cert2.crt',
+            '/fakepath/cert3.crt',
+        );
+        CertFactory::getCertFromFiles($files);
+    }
+
+
     public function testGetCertFromServer()
     {
         $cert = CertFactory::getCertFromServer('www.google.com', 443);
         $this->assertInstanceOf('\Certain\Cert', $cert, 'getCertFromFiles returns Cert.');
     }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetCertFromServerException()
+    {
+        CertFactory::getCertFromServer('localhost', 30000);
+    }
+
 }

--- a/tests/Certain/Test/CertFactoryTest.php
+++ b/tests/Certain/Test/CertFactoryTest.php
@@ -13,7 +13,6 @@ namespace Certain\Test;
 
 use Certain\CertFactory;
 
-
 class CertFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetCertFromChain()
@@ -68,7 +67,6 @@ class CertFactoryTest extends \PHPUnit_Framework_TestCase
         );
         CertFactory::getCertFromFiles($files);
     }
-
 
     public function testGetCertFromServer()
     {

--- a/tests/Certain/Test/CertTest.php
+++ b/tests/Certain/Test/CertTest.php
@@ -35,18 +35,15 @@ class CertTest extends \PHPUnit_Framework_TestCase
         return CertFactory::getCertFromFiles($certPaths);
     }
 
-    public function testSetHost()
+
+    public function testConstruct()
     {
 
     }
 
-    public function testGetParameters()
+    public function testSetHost()
     {
-        $cert = static::getTestChain('Google');
 
-        $parameters = $cert->getParameters();
-        $this->assertInternalType('array', $parameters, 'getParameters returns array');
-        $this->assertGreaterThan(0, count($parameters), 'Parameters array not empty.');
     }
 
     public function testGetParent()
@@ -59,7 +56,22 @@ class CertTest extends \PHPUnit_Framework_TestCase
 
         $grandParent = $parent->getParent();
         $this->assertInstanceOf('\Certain\Cert', $grandParent, 'getCertFromFiles properly populates grand parent');
-
     }
 
+    public function testGetOpenSSLCert()
+    {
+        $cert = $this->getTestChain('Google');
+        $sslCert = $cert->getOpenSSLCert();
+        $this->assertInternalType('resource', $sslCert, 'Returns resource.');
+        $this->assertEquals('OpenSSL X.509', get_resource_type($sslCert), 'Resources is of type OpenSSL X.509');
+    }
+
+    public function testGetParameters()
+    {
+        $cert = static::getTestChain('Google');
+
+        $parameters = $cert->getParameters();
+        $this->assertInternalType('array', $parameters, 'getParameters returns array');
+        $this->assertGreaterThan(0, count($parameters), 'Parameters array not empty.');
+    }
 }

--- a/tests/Certain/Test/CertTest.php
+++ b/tests/Certain/Test/CertTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the Certain package.
  *
@@ -73,5 +72,27 @@ class CertTest extends \PHPUnit_Framework_TestCase
         $parameters = $cert->getParameters();
         $this->assertInternalType('array', $parameters, 'getParameters returns array');
         $this->assertGreaterThan(0, count($parameters), 'Parameters array not empty.');
+    }
+
+    public function testGetValidFrom()
+    {
+        $cert = $this->getTestChain('Google');
+        $validFrom = $cert->getValidFrom();
+        $this->assertInstanceOf('\DateTime', $validFrom, 'ValidFrom is DateTime.');
+        $this->assertEquals('1389797604', $validFrom->getTimestamp(), 'Returns right timestamp.');
+    }
+
+    public function testGetValidTo()
+    {
+        $cert = $this->getTestChain('Google');
+        $validTo = $cert->getValidTo();
+        $this->assertInstanceOf('\DateTime', $validTo, 'ValidFrom is DateTime.');
+        $this->assertEquals('1400112000', $validTo->getTimestamp(), 'Returns right timestamp.');
+    }
+
+    public function testGetCommonName()
+    {
+        $cert = $this->getTestChain('Google');
+        $this->assertEquals('www.google.com', $cert->getCommonName());
     }
 }

--- a/tests/Certain/Test/CertTest.php
+++ b/tests/Certain/Test/CertTest.php
@@ -34,7 +34,6 @@ class CertTest extends \PHPUnit_Framework_TestCase
         return CertFactory::getCertFromFiles($certPaths);
     }
 
-
     public function testConstruct()
     {
 

--- a/tests/Certain/Test/UtilTest.php
+++ b/tests/Certain/Test/UtilTest.php
@@ -11,8 +11,8 @@ namespace Certain\Test;
 
 use Certain\Util;
 
-class UtilTest extends \PHPUnit_Framework_TestCase {
-
+class UtilTest extends \PHPUnit_Framework_TestCase
+{
     public function testGetDateFromSSLFormat()
     {
         $fromDate = Util::getDateFromSSLFormat('140115145324Z');
@@ -22,4 +22,3 @@ class UtilTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('1400112000', $validTo->getTimestamp(), 'Returns the right date.');
     }
 }
- 

--- a/tests/Certain/Test/UtilTest.php
+++ b/tests/Certain/Test/UtilTest.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * This file is part of the Certain package.
+ *
+ * (c) Robert Hafner <tedivm@tedivm.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Certain\Test;
+
+use Certain\Util;
+
+class UtilTest extends \PHPUnit_Framework_TestCase {
+
+    public function testGetDateFromSSLFormat()
+    {
+        $fromDate = Util::getDateFromSSLFormat('140115145324Z');
+        $this->assertEquals('1389797604', $fromDate->getTimestamp(), 'Returns the right date.');
+
+        $validTo = Util::getDateFromSSLFormat('140515000000Z');
+        $this->assertEquals('1400112000', $validTo->getTimestamp(), 'Returns the right date.');
+    }
+}
+ 

--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -9,4 +9,4 @@ echo ''
 echo ''
 echo 'Testing for Coding Styling Compliance.'
 echo 'All code should follow PSR standards.'
-./vendor/fabpot/php-cs-fixer/php-cs-fixer fix ./ --dry-run --level="all" -vv
+./vendor/fabpot/php-cs-fixer/php-cs-fixer fix ./ --level="all" -vv --dry-run


### PR DESCRIPTION
All parameters are now accessible, and helpful wrappers are setup around certain more commonly used ones (such as a pair of functions to return the "valid from" and "valid to" times as PHP DateTime objects).
